### PR TITLE
Point to the user's home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ## Usage
 
 1. Clone this repository locally
-2. Copy the selected theme from `src` to `/usr/share/plank/themes`:
+2. Copy the selected theme from `src` to `~/.local/share/plank/themes`:
     - 🌻 Catppuccin-latte
     - 🪴 Catppuccin-frappe
     - 🌺 Catppuccin-macchiato


### PR DESCRIPTION
The home version also works and is usually the better option instead of overriding any of the system paths which are usually only touched by packages installed globally.